### PR TITLE
[issue #15] kafka 알림 서비스 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     implementation("org.mindrot:jbcrypt:0.4")
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation("org.springframework.session:spring-session-data-redis")
+    implementation("org.springframework.kafka:spring-kafka")
     compileOnly("org.projectlombok:lombok")
     runtimeOnly("com.mysql:mysql-connector-j")
     annotationProcessor("org.projectlombok:lombok")

--- a/src/main/java/xeonu/bankingserver/account/entity/dto/AlarmKafkaTopic.java
+++ b/src/main/java/xeonu/bankingserver/account/entity/dto/AlarmKafkaTopic.java
@@ -1,0 +1,17 @@
+package xeonu.bankingserver.account.entity.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AlarmKafkaTopic {
+
+  private int receiverId;
+
+  private String message;
+}

--- a/src/main/java/xeonu/bankingserver/alarm/service/MockAlarmService.java
+++ b/src/main/java/xeonu/bankingserver/alarm/service/MockAlarmService.java
@@ -2,6 +2,7 @@ package xeonu.bankingserver.alarm.service;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Primary;
+import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -10,6 +11,7 @@ import org.springframework.stereotype.Service;
 public class MockAlarmService implements AlarmService {
 
   @Override
+  @KafkaListener(topics = "alarm", groupId = "alarm-group")
   public void sendAlarmMessage(int memberId, String message) {
     log.info("send {} to member {}", message, memberId);
     try {

--- a/src/main/java/xeonu/bankingserver/common/config/KafkaConfig.java
+++ b/src/main/java/xeonu/bankingserver/common/config/KafkaConfig.java
@@ -1,0 +1,63 @@
+package xeonu.bankingserver.common.config;
+
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.deser.std.StringDeserializer;
+import com.fasterxml.jackson.databind.ser.std.StringSerializer;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import xeonu.bankingserver.account.entity.dto.AlarmKafkaTopic;
+
+@Configuration
+public class KafkaConfig {
+
+  @Value("${spring.kafka.bootstrap-servers}")
+  private String bootstrapServers;
+
+  @Bean
+  public ProducerFactory<String, AlarmKafkaTopic> producerFactory() {
+
+    Map<String, Object> configs = new HashMap<>();
+    configs.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    configs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    configs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+    return new DefaultKafkaProducerFactory(configs);
+  }
+
+  @Bean
+  public KafkaTemplate<String, AlarmKafkaTopic> kafkaTemplate() {
+
+    return new KafkaTemplate<>(producerFactory());
+  }
+
+  @Bean
+  public ConsumerFactory<String, AlarmKafkaTopic> consumerFactory() {
+
+    Map<String, Object> configs = new HashMap<>();
+    configs.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    configs.put(ConsumerConfig.GROUP_ID_CONFIG, "alarm-group");
+
+    return new DefaultKafkaConsumerFactory<>(
+        configs,
+        new StringDeserializer(),
+        new JsonDeserializer<>(AlarmKafkaTopic.class));
+  }
+
+  @Bean
+  public ConcurrentKafkaListenerContainerFactory<String, AlarmKafkaTopic> alarmListener() {
+    ConcurrentKafkaListenerContainerFactory<String, AlarmKafkaTopic> factory = new ConcurrentKafkaListenerContainerFactory<>();
+    factory.setConsumerFactory(consumerFactory());
+    return factory;
+  }
+}


### PR DESCRIPTION
# 변경 사항
- 알림서버에 장애가 발생해도 계좌이체가 정상적으로 동작하기 위해 알림서버로 전송할 때 kafka를 통해서 전송